### PR TITLE
Replace nodejs prom-client with promjs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish npm package to gitea
+on:
+  release:
+    types: [published]
+jobs:
+  npm_publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 16.x ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn
+      - name: Run yarn build
+        run: |
+          yarn build
+      - name: Configure git.vdb.to npm registry
+        run: |
+          npm config set registry https://git.vdb.to/api/packages/cerc-io/npm/
+      - name: Authenticate to git.vdb.to registry
+        run: |
+          npm config set -- '//git.vdb.to/api/packages/cerc-io/npm/:_authToken' "${{ secrets.GITEA_PUBLISH_TOKEN }}"
+      - name: npm publish
+        run: |
+          npm publish

--- a/README.md
+++ b/README.md
@@ -40,15 +40,10 @@ const node = await createLibp2p({
 })
 ```
 
-Then use the `prom-client` module to supply metrics to the Prometheus/Graphana client using your http framework:
+Then use the `getMetrics` method to get stringified metrics:
 
 ```js
-import client from 'prom-client'
-
-async handler (request, h) {
-  return h.response(await client.register.metrics())
-    .type(client.register.contentType)
-}
+const metricsString = await node.metrics.getMetrics()
 ```
 
 All Prometheus metrics are global so there's no other work required to extract them.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@libp2p/prometheus-metrics",
+  "name": "@cerc-io/prom-browser-metrics",
   "version": "1.1.3",
   "description": "Collect libp2p metrics for scraping by Prometheus or Graphana",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
     "@libp2p/interface-metrics": "^4.0.2",
     "@libp2p/logger": "^2.0.2",
     "it-foreach": "^1.0.0",
-    "it-stream-types": "^1.0.4"
+    "it-stream-types": "^1.0.4",
+    "promjs": "^0.4.2"
   },
   "devDependencies": {
     "@libp2p/interface-mocks": "^8.0.4",

--- a/package.json
+++ b/package.json
@@ -126,9 +126,9 @@
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
     "build": "aegir build",
-    "test": "aegir test -t node",
-    "test:node": "aegir test -t node --cov",
-    "test:electron-main": "aegir test -t electron-main --cov",
+    "test": "aegir test -t browser",
+    "test:chrome": "aegir test -t browser -f \"./dist/test/**/*.spec.js\" --cov",
+    "test:firefox": "aegir test -t browser -f \"./dist/test/**/*.spec.js\" -- --browser firefox",
     "release": "aegir release",
     "docs": "aegir docs"
   },
@@ -141,18 +141,14 @@
     "promjs": "^0.4.2"
   },
   "devDependencies": {
-    "@libp2p/interface-mocks": "^8.0.4",
-    "@libp2p/peer-id-factory": "^1.0.19",
+    "@libp2p/interface-mocks": "^9.1.1",
+    "@libp2p/peer-id-factory": "^2.0.1",
     "@multiformats/multiaddr": "^11.0.7",
     "aegir": "^37.5.6",
     "it-drain": "^2.0.0",
     "it-pair": "^2.0.3",
     "it-pipe": "^2.0.4",
     "p-defer": "^4.0.0",
-    "prom-client": "^14.1.0",
     "uint8arraylist": "^2.3.3"
-  },
-  "peerDependencies": {
-    "prom-client": "^14.1.0"
   }
 }

--- a/src/counter-group.ts
+++ b/src/counter-group.ts
@@ -1,43 +1,42 @@
 import type { CounterGroup, CalculateMetric } from '@libp2p/interface-metrics'
-import { Counter as PromCounter, CollectFunction } from 'prom-client'
+import type { CounterType } from 'promjs'
 import { normaliseString, CalculatedMetric } from './utils.js'
 import type { PrometheusCalculatedMetricOptions } from './index.js'
 
 export class PrometheusCounterGroup implements CounterGroup, CalculatedMetric<Record<string, number>> {
-  private readonly counter: PromCounter
+  private readonly counter: CounterType
   private readonly label: string
   private readonly calculators: Array<CalculateMetric<Record<string, number>>>
 
   constructor (name: string, opts: PrometheusCalculatedMetricOptions<Record<string, number>>) {
     name = normaliseString(name)
     const help = normaliseString(opts.help ?? name)
-    const label = this.label = normaliseString(opts.label ?? name)
-    let collect: CollectFunction<PromCounter<any>> | undefined
+    this.label = normaliseString(opts.label ?? name)
+    // let collect: any | undefined
     this.calculators = []
 
     // calculated metric
-    if (opts?.calculate != null) {
-      this.calculators.push(opts.calculate)
-      const self = this
+    // TODO: Implement and use collect
+    // if (opts?.calculate != null) {
+    //   this.calculators.push(opts.calculate)
+    //   const self = this
 
-      collect = async function () {
-        await Promise.all(self.calculators.map(async calculate => {
-          const values = await calculate()
+    //   collect = async function () {
+    //     await Promise.all(self.calculators.map(async calculate => {
+    //       const values = await calculate()
 
-          Object.entries(values).forEach(([key, value]) => {
-            this.inc({ [label]: key }, value)
-          })
-        }))
-      }
-    }
+    //       Object.entries(values).forEach(([key, value]) => {
+    //         this.inc({ [label]: key }, value)
+    //       })
+    //     }))
+    //   }
+    // }
 
-    this.counter = new PromCounter({
+    this.counter = opts.registry.create(
+      'counter',
       name,
-      help,
-      labelNames: [this.label],
-      registers: opts.registry !== undefined ? [opts.registry] : undefined,
-      collect
-    })
+      help
+    )
   }
 
   addCalculator (calculator: CalculateMetric<Record<string, number>>) {
@@ -48,7 +47,7 @@ export class PrometheusCounterGroup implements CounterGroup, CalculatedMetric<Re
     Object.entries(values).forEach(([key, value]) => {
       const inc = typeof value === 'number' ? value : 1
 
-      this.counter.inc({ [this.label]: key }, inc)
+      this.counter.add(inc, { [this.label]: key })
     })
   }
 

--- a/src/counter-group.ts
+++ b/src/counter-group.ts
@@ -49,6 +49,6 @@ export class PrometheusCounterGroup implements CounterGroup, CalculatedMetric<Re
   }
 
   reset (): void {
-    this.counter.reset()
+    this.counter.resetAll()
   }
 }

--- a/src/counter.ts
+++ b/src/counter.ts
@@ -12,28 +12,25 @@ export class PrometheusCounter implements Counter, CalculatedMetric {
     const help = normaliseString(opts.help ?? name)
     // TODO: Use labels in counter (not used in old code)
     // const labels = opts.label != null ? [normaliseString(opts.label)] : []
-    // let collect: any | undefined
     this.calculators = []
 
     // calculated metric
-    // TODO: Implement and use collect
-    // if (opts?.calculate != null) {
-    //   this.calculators.push(opts.calculate)
-    //   const self = this
-
-    //   collect = async function () {
-    //     const values = await Promise.all(self.calculators.map(async calculate => await calculate()))
-    //     const sum = values.reduce((acc, curr) => acc + curr, 0)
-
-    //     this.inc(sum)
-    //   }
-    // }
+    if (opts?.calculate != null) {
+      this.calculators.push(opts.calculate)
+    }
 
     this.counter = opts.registry.create(
       'counter',
       name,
       help
     )
+  }
+
+  async calculate () {
+    const values = await Promise.all(this.calculators.map(async calculate => await calculate()))
+    const sum = values.reduce((acc, curr) => acc + curr, 0)
+
+    this.counter.add(sum)
   }
 
   addCalculator (calculator: CalculateMetric) {

--- a/src/counter.ts
+++ b/src/counter.ts
@@ -1,39 +1,39 @@
 import type { CalculateMetric, Counter } from '@libp2p/interface-metrics'
-import { CollectFunction, Counter as PromCounter } from 'prom-client'
+import type { CounterType } from 'promjs'
 import type { PrometheusCalculatedMetricOptions } from './index.js'
 import { normaliseString, CalculatedMetric } from './utils.js'
 
 export class PrometheusCounter implements Counter, CalculatedMetric {
-  private readonly counter: PromCounter
+  private readonly counter: CounterType
   private readonly calculators: CalculateMetric[]
 
   constructor (name: string, opts: PrometheusCalculatedMetricOptions) {
     name = normaliseString(name)
     const help = normaliseString(opts.help ?? name)
-    const labels = opts.label != null ? [normaliseString(opts.label)] : []
-    let collect: CollectFunction<PromCounter<any>> | undefined
+    // TODO: Use labels in counter (not used in old code)
+    // const labels = opts.label != null ? [normaliseString(opts.label)] : []
+    // let collect: any | undefined
     this.calculators = []
 
     // calculated metric
-    if (opts?.calculate != null) {
-      this.calculators.push(opts.calculate)
-      const self = this
+    // TODO: Implement and use collect
+    // if (opts?.calculate != null) {
+    //   this.calculators.push(opts.calculate)
+    //   const self = this
 
-      collect = async function () {
-        const values = await Promise.all(self.calculators.map(async calculate => await calculate()))
-        const sum = values.reduce((acc, curr) => acc + curr, 0)
+    //   collect = async function () {
+    //     const values = await Promise.all(self.calculators.map(async calculate => await calculate()))
+    //     const sum = values.reduce((acc, curr) => acc + curr, 0)
 
-        this.inc(sum)
-      }
-    }
+    //     this.inc(sum)
+    //   }
+    // }
 
-    this.counter = new PromCounter({
+    this.counter = opts.registry.create(
+      'counter',
       name,
-      help,
-      labelNames: labels,
-      registers: opts.registry !== undefined ? [opts.registry] : undefined,
-      collect
-    })
+      help
+    )
   }
 
   addCalculator (calculator: CalculateMetric) {
@@ -41,7 +41,7 @@ export class PrometheusCounter implements Counter, CalculatedMetric {
   }
 
   increment (value: number = 1): void {
-    this.counter.inc(value)
+    this.counter.add(value)
   }
 
   reset (): void {

--- a/src/counter.ts
+++ b/src/counter.ts
@@ -27,10 +27,12 @@ export class PrometheusCounter implements Counter, CalculatedMetric {
   }
 
   async calculate () {
-    const values = await Promise.all(this.calculators.map(async calculate => await calculate()))
-    const sum = values.reduce((acc, curr) => acc + curr, 0)
+    if (this.calculators.length > 0) {
+      const values = await Promise.all(this.calculators.map(async calculate => await calculate()))
+      const sum = values.reduce((acc, curr) => acc + curr, 0)
 
-    this.counter.add(sum)
+      this.counter.add(sum)
+    }
   }
 
   addCalculator (calculator: CalculateMetric) {

--- a/src/metric-group.ts
+++ b/src/metric-group.ts
@@ -1,43 +1,42 @@
 import type { CalculateMetric, MetricGroup, StopTimer } from '@libp2p/interface-metrics'
-import { CollectFunction, Gauge } from 'prom-client'
+import type { GaugeType } from 'promjs'
 import type { PrometheusCalculatedMetricOptions } from './index.js'
 import { normaliseString, CalculatedMetric } from './utils.js'
 
 export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Record<string, number>> {
-  private readonly gauge: Gauge
+  private readonly gauge: GaugeType
   private readonly label: string
   private readonly calculators: Array<CalculateMetric<Record<string, number>>>
 
   constructor (name: string, opts: PrometheusCalculatedMetricOptions<Record<string, number>>) {
     name = normaliseString(name)
     const help = normaliseString(opts.help ?? name)
-    const label = this.label = normaliseString(opts.label ?? name)
-    let collect: CollectFunction<Gauge<any>> | undefined
+    this.label = normaliseString(opts.label ?? name)
+    // let collect: any | undefined
     this.calculators = []
 
     // calculated metric
-    if (opts?.calculate != null) {
-      this.calculators.push(opts.calculate)
-      const self = this
+    // TODO: Implement and use collect
+    // if (opts?.calculate != null) {
+    //   this.calculators.push(opts.calculate)
+    //   const self = this
 
-      collect = async function () {
-        await Promise.all(self.calculators.map(async calculate => {
-          const values = await calculate()
+    //   collect = async function () {
+    //     await Promise.all(self.calculators.map(async calculate => {
+    //       const values = await calculate()
 
-          Object.entries(values).forEach(([key, value]) => {
-            this.set({ [label]: key }, value)
-          })
-        }))
-      }
-    }
+    //       Object.entries(values).forEach(([key, value]) => {
+    //         this.set({ [label]: key }, value)
+    //       })
+    //     }))
+    //   }
+    // }
 
-    this.gauge = new Gauge({
+    this.gauge = opts.registry.create(
+      'gauge',
       name,
-      help,
-      labelNames: [this.label],
-      registers: opts.registry !== undefined ? [opts.registry] : undefined,
-      collect
-    })
+      help
+    )
   }
 
   addCalculator (calculator: CalculateMetric<Record<string, number>>) {
@@ -46,7 +45,7 @@ export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Reco
 
   update (values: Record<string, number>): void {
     Object.entries(values).forEach(([key, value]) => {
-      this.gauge.set({ [this.label]: key }, value)
+      this.gauge.set(value, { [this.label]: key })
     })
   }
 
@@ -54,7 +53,7 @@ export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Reco
     Object.entries(values).forEach(([key, value]) => {
       const inc = typeof value === 'number' ? value : 1
 
-      this.gauge.inc({ [this.label]: key }, inc)
+      this.gauge.add(inc, { [this.label]: key })
     })
   }
 
@@ -62,7 +61,7 @@ export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Reco
     Object.entries(values).forEach(([key, value]) => {
       const dec = typeof value === 'number' ? value : 1
 
-      this.gauge.dec({ [this.label]: key }, dec)
+      this.gauge.sub(dec, { [this.label]: key })
     })
   }
 
@@ -71,8 +70,14 @@ export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Reco
   }
 
   timer (key: string): StopTimer {
-    return this.gauge.startTimer({
-      key: 0
-    })
+    const startDate = new Date()
+
+    return () => {
+      const timeElapsedInMs = (new Date()).getTime() - startDate.getTime()
+
+      this.gauge.set(timeElapsedInMs / 1000, {
+        key: 0
+      })
+    }
   }
 }

--- a/src/metric-group.ts
+++ b/src/metric-group.ts
@@ -12,31 +12,28 @@ export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Reco
     name = normaliseString(name)
     const help = normaliseString(opts.help ?? name)
     this.label = normaliseString(opts.label ?? name)
-    // let collect: any | undefined
     this.calculators = []
 
     // calculated metric
-    // TODO: Implement and use collect
-    // if (opts?.calculate != null) {
-    //   this.calculators.push(opts.calculate)
-    //   const self = this
-
-    //   collect = async function () {
-    //     await Promise.all(self.calculators.map(async calculate => {
-    //       const values = await calculate()
-
-    //       Object.entries(values).forEach(([key, value]) => {
-    //         this.set({ [label]: key }, value)
-    //       })
-    //     }))
-    //   }
-    // }
+    if (opts?.calculate != null) {
+      this.calculators.push(opts.calculate)
+    }
 
     this.gauge = opts.registry.create(
       'gauge',
       name,
       help
     )
+  }
+
+  async calculate () {
+    await Promise.all(this.calculators.map(async calculate => {
+      const values = await calculate()
+
+      Object.entries(values).forEach(([key, value]) => {
+        this.gauge.set(value, { [this.label]: key })
+      })
+    }))
   }
 
   addCalculator (calculator: CalculateMetric<Record<string, number>>) {

--- a/src/metric-group.ts
+++ b/src/metric-group.ts
@@ -1,7 +1,7 @@
 import type { CalculateMetric, MetricGroup, StopTimer } from '@libp2p/interface-metrics'
 import type { GaugeType } from 'promjs'
 import type { PrometheusCalculatedMetricOptions } from './index.js'
-import { normaliseString, CalculatedMetric } from './utils.js'
+import { normaliseString, CalculatedMetric, decrementGauge } from './utils.js'
 
 export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Record<string, number>> {
   private readonly gauge: GaugeType
@@ -58,12 +58,12 @@ export class PrometheusMetricGroup implements MetricGroup, CalculatedMetric<Reco
     Object.entries(values).forEach(([key, value]) => {
       const dec = typeof value === 'number' ? value : 1
 
-      this.gauge.sub(dec, { [this.label]: key })
+      decrementGauge(this.gauge, dec, { [this.label]: key })
     })
   }
 
   reset (): void {
-    this.gauge.reset()
+    this.gauge.resetAll()
   }
 
   timer (key: string): StopTimer {

--- a/src/metric.ts
+++ b/src/metric.ts
@@ -12,28 +12,25 @@ export class PrometheusMetric implements Metric {
     const help = normaliseString(opts.help ?? name)
     // TODO: Use labels in counter (not used in old code)
     // const labels = opts.label != null ? [normaliseString(opts.label)] : []
-    // let collect: any | undefined
     this.calculators = []
 
     // calculated metric
-    // TODO: Implement and use collect
-    // if (opts?.calculate != null) {
-    //   this.calculators.push(opts.calculate)
-    //   const self = this
-
-    //   collect = async function () {
-    //     const values = await Promise.all(self.calculators.map(async calculate => await calculate()))
-    //     const sum = values.reduce((acc, curr) => acc + curr, 0)
-
-    //     this.set(sum)
-    //   }
-    // }
+    if (opts?.calculate != null) {
+      this.calculators.push(opts.calculate)
+    }
 
     this.gauge = opts.registry.create(
       'gauge',
       name,
       help
     )
+  }
+
+  async calculate () {
+    const values = await Promise.all(this.calculators.map(async calculate => await calculate()))
+    const sum = values.reduce((acc, curr) => acc + curr, 0)
+
+    this.gauge.set(sum)
   }
 
   addCalculator (calculator: CalculateMetric) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import type { CalculateMetric } from '@libp2p/interface-metrics'
+import type { GaugeType, Labels } from 'promjs'
 
 export interface CalculatedMetric <T = number> {
   addCalculator: (calculator: CalculateMetric<T>) => void
@@ -15,4 +16,22 @@ export function normaliseString (str: string): string {
   return str
     .replace(/[^a-zA-Z0-9_]/g, '_')
     .replace(/_+/g, '_')
+}
+
+/**
+ * Method to decrement gauge like prom-client when metric value is not set
+ * Default value is set to zero
+ *
+ * @param gauge
+ * @param dec
+ * @param labels
+ */
+export function decrementGauge (gauge: GaugeType, dec: number, labels?: Labels) {
+  const oldMetric = gauge.get(labels)
+
+  if (oldMetric == null) {
+    return gauge.set(-dec, labels)
+  }
+
+  return gauge.sub(dec, labels)
 }

--- a/test/counter-groups.spec.ts
+++ b/test/counter-groups.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'aegir/chai'
 import { prometheusMetrics } from '../src/index.js'
-import client from 'prom-client'
 import { randomMetricName } from './fixtures/random-metric-name.js'
 
 describe('counter groups', () => {
@@ -16,7 +15,7 @@ describe('counter groups', () => {
       [metricKey]: true
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} 1`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} 1`, 'did not include updated metric')
   })
 
   it('should increment a counter group with a value', async () => {
@@ -32,7 +31,7 @@ describe('counter groups', () => {
       [metricKey]: metricValue
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
   })
 
   it('should calculate a counter group value', async () => {
@@ -50,7 +49,7 @@ describe('counter groups', () => {
       }
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
   })
 
   it('should promise to calculate a counter group value', async () => {
@@ -68,7 +67,7 @@ describe('counter groups', () => {
       }
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
   })
 
   it('should reset a counter group', async () => {
@@ -84,11 +83,11 @@ describe('counter groups', () => {
       [metricKey]: metricValue
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
 
     metric.reset()
 
-    await expect(client.register.metrics()).to.eventually.not.include(metricKey, 'still included metric key')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${0}`, 'did not reset metric key')
   })
 
   it('should allow use of the same counter group from multiple reporters', async () => {
@@ -112,7 +111,7 @@ describe('counter groups', () => {
       [metricKey2]: metricValue2
     })
 
-    const reportedMetrics = await client.register.metrics()
+    const reportedMetrics = await metrics.getMetrics()
 
     expect(reportedMetrics).to.include(`${metricName}{${metricLabel}="${metricKey1}"} ${metricValue1}`, 'did not include updated metric')
     expect(reportedMetrics).to.include(`${metricName}{${metricLabel}="${metricKey2}"} ${metricValue2}`, 'did not include updated metric')

--- a/test/counters.spec.ts
+++ b/test/counters.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'aegir/chai'
 import { prometheusMetrics } from '../src/index.js'
-import client from 'prom-client'
 import { randomMetricName } from './fixtures/random-metric-name.js'
 
 describe('counters', () => {
@@ -10,7 +9,7 @@ describe('counters', () => {
     const metric = metrics.registerCounter(metricName)
     metric.increment()
 
-    const report = await client.register.metrics()
+    const report = await metrics.getMetrics()
     expect(report).to.include(`# TYPE ${metricName} counter`, 'did not include metric type')
     expect(report).to.include(`${metricName} 1`, 'did not include updated metric')
   })
@@ -22,7 +21,7 @@ describe('counters', () => {
     const metric = metrics.registerCounter(metricName)
     metric.increment(metricValue)
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName} ${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName} ${metricValue}`, 'did not include updated metric')
   })
 
   it('should calculate a counter', async () => {
@@ -35,7 +34,7 @@ describe('counters', () => {
       }
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName} ${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName} ${metricValue}`, 'did not include updated metric')
   })
 
   it('should promise to calculate a counter', async () => {
@@ -48,7 +47,7 @@ describe('counters', () => {
       }
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName} ${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName} ${metricValue}`, 'did not include updated metric')
   })
 
   it('should reset a counter', async () => {
@@ -58,11 +57,11 @@ describe('counters', () => {
     const metric = metrics.registerCounter(metricName)
     metric.increment(metricValue)
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName} ${metricValue}`)
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName} ${metricValue}`)
 
     metric.reset()
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName} 0`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName} 0`, 'did not include updated metric')
   })
 
   it('should allow use of the same counter from multiple reporters', async () => {
@@ -80,6 +79,6 @@ describe('counters', () => {
     })
     metric2.increment(metricValue2)
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName} ${metricValue1 + metricValue2}`)
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName} ${metricValue1 + metricValue2}`)
   })
 })

--- a/test/custom-registry.spec.ts
+++ b/test/custom-registry.spec.ts
@@ -1,23 +1,33 @@
 import { expect } from 'aegir/chai'
 import { prometheusMetrics } from '../src/index.js'
-import client, { Registry } from 'prom-client'
+import promImport, { RegistryType } from 'promjs'
 import { randomMetricName } from './fixtures/random-metric-name.js'
 
 describe('custom registry', () => {
-  it('should set a metric in the custom registry and not in the global registry', async () => {
+  it('should set a metric in the custom registry', async () => {
+    // Workaround for using incorrect import according to promjs types
+    const { default: prom } = (promImport as unknown) as { default: () => RegistryType }
+    const registry = prom()
+
     const metricName = randomMetricName()
     const metricValue = 5
-    const registry = new Registry()
-    const metrics = prometheusMetrics({ registry })()
+
+    const promOptions = {
+      registry,
+      // Passing empty method as custom registry doesn't calculate metrics on scraping
+      // TODO: Add method in metrics to get values for specified metric
+      calculateMemory: () => ({})
+    }
+
+    const metrics = prometheusMetrics(promOptions)()
     const metric = metrics.registerMetric(metricName)
     metric.update(metricValue)
 
-    const customRegistryReport = await registry.metrics()
+    const customRegistryReport = registry.metrics()
     expect(customRegistryReport).to.include(`# TYPE ${metricName} gauge`, 'did not include metric type')
     expect(customRegistryReport).to.include(`${metricName} ${metricValue}`, 'did not include updated metric')
 
-    const globalRegistryReport = await client.register.metrics()
-    expect(globalRegistryReport).to.not.include(`# TYPE ${metricName} gauge`, 'erroneously includes metric type')
-    expect(globalRegistryReport).to.not.include(`${metricName} ${metricValue}`, 'erroneously includes updated metric')
+    const internalRegistryReport = await metrics.getMetrics()
+    expect(internalRegistryReport).to.be.equal(customRegistryReport)
   })
 })

--- a/test/metric-groups.spec.ts
+++ b/test/metric-groups.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'aegir/chai'
 import { prometheusMetrics } from '../src/index.js'
-import client from 'prom-client'
 import { randomMetricName } from './fixtures/random-metric-name.js'
 
 describe('metric groups', () => {
@@ -17,7 +16,7 @@ describe('metric groups', () => {
       [metricKey]: metricValue
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
   })
 
   it('should increment a metric group without a value', async () => {
@@ -32,7 +31,7 @@ describe('metric groups', () => {
       [metricKey]: false
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} 1`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} 1`, 'did not include updated metric')
   })
 
   it('should increment a metric group with a value', async () => {
@@ -48,7 +47,7 @@ describe('metric groups', () => {
       [metricKey]: metricValue
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
   })
 
   it('should decrement a metric group without a value', async () => {
@@ -63,7 +62,7 @@ describe('metric groups', () => {
       [metricKey]: false
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} -1`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} -1`, 'did not include updated metric')
   })
 
   it('should decrement a metric group with a value', async () => {
@@ -79,7 +78,7 @@ describe('metric groups', () => {
       [metricKey]: metricValue
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} -${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} -${metricValue}`, 'did not include updated metric')
   })
 
   it('should calculate a metric group value', async () => {
@@ -97,7 +96,7 @@ describe('metric groups', () => {
       }
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
   })
 
   it('should promise to calculate a metric group value', async () => {
@@ -115,7 +114,7 @@ describe('metric groups', () => {
       }
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
   })
 
   it('should reset a metric group', async () => {
@@ -131,11 +130,11 @@ describe('metric groups', () => {
       [metricKey]: metricValue
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${metricValue}`, 'did not include updated metric')
 
     metric.reset()
 
-    await expect(client.register.metrics()).to.eventually.not.include(metricKey, 'still included metric key')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName}{${metricLabel}="${metricKey}"} ${0}`, 'did not reset metric key')
   })
 
   it('should allow use of the same metric group from multiple reporters', async () => {
@@ -159,7 +158,7 @@ describe('metric groups', () => {
       [metricKey2]: metricValue2
     })
 
-    const reportedMetrics = await client.register.metrics()
+    const reportedMetrics = await metrics.getMetrics()
 
     expect(reportedMetrics).to.include(`${metricName}{${metricLabel}="${metricKey1}"} ${metricValue1}`, 'did not include updated metric')
     expect(reportedMetrics).to.include(`${metricName}{${metricLabel}="${metricKey2}"} ${metricValue2}`, 'did not include updated metric')

--- a/test/metrics.spec.ts
+++ b/test/metrics.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'aegir/chai'
 import { prometheusMetrics } from '../src/index.js'
-import client from 'prom-client'
 import { randomMetricName } from './fixtures/random-metric-name.js'
 
 describe('metrics', () => {
@@ -11,7 +10,7 @@ describe('metrics', () => {
     const metric = metrics.registerMetric(metricName)
     metric.update(metricValue)
 
-    const report = await client.register.metrics()
+    const report = await metrics.getMetrics()
     expect(report).to.include(`# TYPE ${metricName} gauge`, 'did not include metric type')
     expect(report).to.include(`${metricName} ${metricValue}`, 'did not include updated metric')
   })
@@ -22,7 +21,7 @@ describe('metrics', () => {
     const metric = metrics.registerMetric(metricName)
     metric.increment()
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName} 1`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName} 1`, 'did not include updated metric')
   })
 
   it('should increment a metric with a value', async () => {
@@ -32,7 +31,7 @@ describe('metrics', () => {
     const metric = metrics.registerMetric(metricName)
     metric.increment(metricValue)
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName} ${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName} ${metricValue}`, 'did not include updated metric')
   })
 
   it('should decrement a metric without a value', async () => {
@@ -41,7 +40,7 @@ describe('metrics', () => {
     const metric = metrics.registerMetric(metricName)
     metric.decrement()
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName} -1`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName} -1`, 'did not include updated metric')
   })
 
   it('should decrement a metric with a value', async () => {
@@ -51,7 +50,7 @@ describe('metrics', () => {
     const metric = metrics.registerMetric(metricName)
     metric.decrement(metricValue)
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName} -${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName} -${metricValue}`, 'did not include updated metric')
   })
 
   it('should calculate a metric', async () => {
@@ -64,7 +63,7 @@ describe('metrics', () => {
       }
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName} ${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName} ${metricValue}`, 'did not include updated metric')
   })
 
   it('should promise to calculate a metric', async () => {
@@ -77,7 +76,7 @@ describe('metrics', () => {
       }
     })
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName} ${metricValue}`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName} ${metricValue}`, 'did not include updated metric')
   })
 
   it('should reset a metric', async () => {
@@ -87,11 +86,11 @@ describe('metrics', () => {
     const metric = metrics.registerMetric(metricName)
     metric.update(metricValue)
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName} ${metricValue}`)
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName} ${metricValue}`)
 
     metric.reset()
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName} 0`, 'did not include updated metric')
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName} 0`, 'did not include updated metric')
   })
 
   it('should allow use of the same metric from multiple reporters', async () => {
@@ -109,6 +108,6 @@ describe('metrics', () => {
     })
     metric2.update(metricValue2)
 
-    await expect(client.register.metrics()).to.eventually.include(`${metricName} ${metricValue2}`)
+    await expect(metrics.getMetrics()).to.eventually.include(`${metricName} ${metricValue2}`)
   })
 })

--- a/test/streams.spec.ts
+++ b/test/streams.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'aegir/chai'
 import { prometheusMetrics } from '../src/index.js'
-import client from 'prom-client'
 import type { Connection } from '@libp2p/interface-connection'
 import { connectionPair, mockRegistrar, mockMultiaddrConnPair } from '@libp2p/interface-mocks'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -54,7 +53,7 @@ describe('streams', () => {
     // wait for all bytes to be received
     await deferred.promise
 
-    const scrapedMetrics = await client.register.metrics()
+    const scrapedMetrics = await metrics.getMetrics()
     expect(scrapedMetrics).to.include(`libp2p_data_transfer_bytes_total{protocol="global sent"} ${data.length}`)
   })
 
@@ -89,7 +88,7 @@ describe('streams', () => {
     // wait for all bytes to be received
     await deferred.promise
 
-    const scrapedMetrics = await client.register.metrics()
+    const scrapedMetrics = await metrics.getMetrics()
     expect(scrapedMetrics).to.include(`libp2p_data_transfer_bytes_total{protocol="global received"} ${data.length}`)
   })
 
@@ -121,7 +120,7 @@ describe('streams', () => {
       data
     ])
 
-    const scrapedMetrics = await client.register.metrics()
+    const scrapedMetrics = await metrics.getMetrics()
     expect(scrapedMetrics).to.include(`libp2p_data_transfer_bytes_total{protocol="${protocol} sent"} ${data.length}`)
   })
 
@@ -161,7 +160,7 @@ describe('streams', () => {
     // wait for data to have been transferred
     await deferred.promise
 
-    const scrapedMetrics = await client.register.metrics()
+    const scrapedMetrics = await metrics.getMetrics()
     expect(scrapedMetrics).to.include(`libp2p_data_transfer_bytes_total{protocol="${protocol} received"} ${data.length}`)
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,6 @@
   },
   "include": [
     "src",
-    // "test"
+    "test"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,6 @@
   },
   "include": [
     "src",
-    "test"
+    // "test"
   ]
 }


### PR DESCRIPTION
Part of cerc-io/watcher-ts#289

- Use `promjs` instead of `prom-client` to enable libp2p metrics in browser
- Add `getMetrics` method to run async calculations and get updated metrics (similar to `prom-client` collect option)
- Update tests and remove `prom-client`